### PR TITLE
Add PHILIP-MORRIS-INTERNATIONAL-INC slug to PM onvista mapping

### DIFF
--- a/warrants_searcher_v6_fixed_3.py
+++ b/warrants_searcher_v6_fixed_3.py
@@ -347,7 +347,7 @@ class INGOptionsFinder:
             "PG": ["Procter-Gamble"],
             "KO": ["Coca-Cola"],
             "MO": ["Altria-Group"],
-            "PM": ["Philip-Morris-International"],
+            "PM": ["PHILIP-MORRIS-INTERNATIONAL-INC", "Philip-Morris-International"],
             "WMT": ["Walmart"],
             "PEP": ["PepsiCo"],
             


### PR DESCRIPTION
### Motivation
- Onvista uses the full slug `PHILIP-MORRIS-INTERNATIONAL-INC` for some warrants pages and the existing `PM` mapping (`Philip-Morris-International`) could miss those links, causing incorrect lookups.

### Description
- Update `warrants_searcher_v6_fixed_3.py` by changing the `ticker_map` entry for `"PM"` to `["PHILIP-MORRIS-INTERNATIONAL-INC", "Philip-Morris-International"]` so both variants are recognized.

### Testing
- No automated tests were run for this mapping-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985b4d5fffc83288b618af7c619b38d)