### PR TITLE
Use onvista break-even when available

### DIFF
--- a/warrants_searcher_v6_fixed_3.py
+++ b/warrants_searcher_v6_fixed_3.py
@@ -1098,6 +1098,8 @@ class INGOptionsFinder:
                     date_match = re.search(r'\d{2}\.\d{2}\.\d{4}', value)
                     if date_match:
                         detail_data["laufzeit_datum"] = date_match.group(0)
+                if "break even" in label or "breakeven" in label or "break-even" in label:
+                    detail_data["break_even"] = self._parse_number(value)
             self.details_cache[detail_url] = detail_data
             return detail_data
         except Exception:
@@ -1119,6 +1121,8 @@ class INGOptionsFinder:
                 opt['restlaufzeit_tage'] = detail["restlaufzeit_tage"]
             if detail.get("laufzeit_datum"):
                 opt['laufzeit'] = detail["laufzeit_datum"]
+            if detail.get("break_even"):
+                opt['break_even'] = detail["break_even"]
             time.sleep(self.delay / 2)
     
     def calculate_theta_per_day(self, option: Dict, days_to_maturity: int) -> float:
@@ -1192,6 +1196,14 @@ class INGOptionsFinder:
         else:
             breakeven = strike - premium_underlying
             move_needed = ((current_price - breakeven) / current_price) * 100
+
+        detail_break_even = option.get("break_even")
+        if isinstance(detail_break_even, (int, float)) and detail_break_even > 0:
+            breakeven = detail_break_even
+            if is_call:
+                move_needed = ((breakeven - current_price) / current_price) * 100
+            else:
+                move_needed = ((current_price - breakeven) / current_price) * 100
         
         # Intrinsic vs. Extrinsic Value
         if is_call:


### PR DESCRIPTION
### Motivation
- Improve accuracy of move calculations by using the break-even value reported on the onvista option detail pages when present.
- Avoid misleading move-needed and breakeven estimates that can differ from onvista's own product details.

### Description
- Parse `break even` / `breakeven` / `break-even` labels from onvista detail pages in `_fetch_option_details` and store as `break_even` in the detail cache.
- Propagate the parsed `break_even` into option dicts during `enrich_options_with_details` as `opt['break_even']`.
- Prefer the detail-sourced `break_even` value when computing `breakeven` and `move_needed` inside `score_option`, falling back to the calculated breakeven when the detail value is missing or invalid.
- Modified file: `warrants_searcher_v6_fixed_3.py`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985dcdbcc648328b0876390116242e0)