### PR TITLE
Add GitHub Actions workflow to test script across multiple Python versions

### DIFF
--- a/.github/workflows/python-script.yml
+++ b/.github/workflows/python-script.yml
@@ -1,0 +1,26 @@
+name: Test script on multiple Python versions
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test-script:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Verify script syntax
+        run: python -m py_compile warrants_searcher_v6_fixed_3.py


### PR DESCRIPTION
### Motivation
- Add CI to verify the repository's main script compiles across supported Python versions to catch syntax errors early.

### Description
- Add `.github/workflows/python-script.yml` which checks out the repo, sets up Python `3.9`, `3.10`, `3.11`, and `3.12`, and runs `python -m py_compile warrants_searcher_v6_fixed_3.py` to verify syntax.

### Testing
- No automated tests were executed in this change; the workflow was added and will run on `push` and `pull_request` events when triggered by CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862edb88a0832897ac2514a2038adf)