### PR TITLE
Add optional email delivery for final top-3 warrants output

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,32 @@ Zusätzlich gibt das Skript eine **Positionsgröße für 200€ Einsatz** aus (m
 
 ---
 
+
+## Mailversand der finalen Top 3 (für Cronjobs)
+
+Das Skript kann nach dem Konsolen-Output optional eine Mail mit genau den finalen **Top 3 Optionsscheinen** senden.
+
+Dafür folgende Umgebungsvariablen setzen:
+
+```bash
+export TOP3_EMAIL_TO=dein.empfaenger@example.com
+export TOP3_SMTP_HOST=smtp.gmail.com
+export TOP3_SMTP_PORT=587
+export TOP3_SMTP_USER=dein.smtp.user@example.com
+export TOP3_SMTP_PASSWORD='dein-passwort-oder-app-passwort'
+# optional:
+export TOP3_EMAIL_FROM=dein.absender@example.com
+export TOP3_SMTP_USE_TLS=1
+```
+
+Wenn `TOP3_EMAIL_TO` oder SMTP-Login fehlen, wird der Mailversand sauber übersprungen und das Skript läuft normal weiter.
+
+Beispiel für `crontab` (3x pro Tag):
+
+```bash
+0 8,12,16 * * 1-5 cd /pfad/zum/repo && /usr/bin/python3 warrants_searcher_v6_fixed_3.py >> scanner.log 2>&1
+```
+
 ## Anpassungsideen (falls du erweitern willst)
 
 - Andere Laufzeiten (z. B. 20–30 Tage) ermöglichen


### PR DESCRIPTION
### Motivation

- Ermögliche das automatische Versenden des finalen Top‑3‑Outputs per E‑Mail, damit das Skript via `crontab` regelmäßig ausgeführt und die Ergebnisse zugestellt werden können.

### Description

- Ergänzt `smtplib` und `EmailMessage` und fügt die Funktion `send_top3_email(top3_text: str)` hinzu, die SMTP‑Konfiguration aus Umgebungsvariablen (`TOP3_EMAIL_TO`, `TOP3_SMTP_*`, optional `TOP3_EMAIL_FROM`, `TOP3_SMTP_USE_TLS`) liest und per STARTTLS versendet.
- Refaktoriert die finale Ausgabe, indem alle Konsolenzeilen in `final_lines` gesammelt werden und nach unveränderter Konsolenausgabe einmalig `send_top3_email("\n".join(final_lines))` aufgerufen wird.
- Dokumentiert die neue Mail‑Option und notwendige Umgebungsvariablen sowie ein `crontab`‑Beispiel in `README.md` unter „Mailversand der finalen Top 3 (für Cronjobs)".
- Der Mailversand wird sauber übersprungen und mit einer Info‑Meldung quittiert, wenn `TOP3_EMAIL_TO` oder SMTP‑Login nicht gesetzt sind, und Fehler beim Versand brechen den Lauf nicht ab.

### Testing

- Automatischer Syntax‑Check via `python -m py_compile warrants_searcher_v6_fixed_3.py` wurde erfolgreich ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb03142388328a46b7f2cba1f03d1)