### PR TITLE
Add JSON-based trading log dashboard for optionschein post-analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,3 +213,30 @@ Beispiel für `crontab` (3x pro Tag):
 
 - **`warrants_searcher_v6_fixed_3.py`** → Komplettes Skript (Basiswert‑Check, Onvista‑Scraping, Scoring)
 - **`top_optionsscheine_ing.csv`** → Output der letzten Analyse (wird beim Lauf überschrieben)
+
+## Trading-Logbuch Dashboard (neu)
+
+Zusätzlich gibt es jetzt ein kleines **Web-Dashboard** für die Nachbetrachtung deiner Trades:
+
+- Datei: `dashboard/index.html`
+- Funktionen:
+  - JSON-Upload (ein Objekt oder Array)
+  - Persistenz im Browser (`localStorage`)
+  - KPI-Kacheln (z. B. Ø Score, Ø Spread, Ø Theta/Tag, Ø Risiko)
+  - Tabellenansicht inkl. Stakeholder-Info
+  - Beispiel-Datensatz per Klick (deine zwei Beispiel-Optionsscheine)
+
+### Start
+
+Einfach lokal im Browser öffnen:
+
+```bash
+xdg-open dashboard/index.html
+```
+
+oder auf einem kleinen lokalen Server:
+
+```bash
+python -m http.server 8000
+# dann http://localhost:8000/dashboard/index.html
+```

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,207 @@
+const STORAGE_KEY = 'trading-logbook-v1';
+
+const schemaExample = [
+  {
+    rank: 3,
+    name: 'BAYN.DE CALL',
+    wkn: 'VJ0QX5',
+    score: 92,
+    scoreMax: 115,
+    strike: 44.0,
+    price: 2.32,
+    spreadPct: 0.48,
+    omega: 14.9,
+    leverage: 21.7,
+    durationDays: 13,
+    impliedVolPct: 36.2,
+    premiumPct: 1.6,
+    thetaPerDayPct: 5.0,
+    breakEvenMovePct: 0.8,
+    issuer: 'Vontobel',
+    stakeholderInfo:
+      'enger Spread, geringer Zeitwertverlust, Break-even mit kleiner Bewegung erreichbar',
+    setup200: {
+      pieces: 86,
+      entry: 2.32,
+      stop: 2.088,
+      cost: 199.52,
+      risk: 19.95,
+    },
+  },
+];
+
+const sampleData = [
+  {
+    rank: 3,
+    name: 'BAYN.DE CALL',
+    wkn: 'VJ0QX5',
+    score: 92,
+    scoreMax: 115,
+    strike: 44.0,
+    price: 2.32,
+    spreadPct: 0.48,
+    omega: 14.9,
+    leverage: 21.7,
+    durationDays: 13,
+    impliedVolPct: 36.2,
+    premiumPct: 1.6,
+    thetaPerDayPct: 5.0,
+    breakEvenMovePct: 0.8,
+    issuer: 'Vontobel',
+    stakeholderInfo:
+      'Fokus auf BAYN.DE mit enger Ausführung und niedriger Theta-Belastung.',
+    setup200: { pieces: 86, entry: 2.32, stop: 2.088, cost: 199.52, risk: 19.95 },
+  },
+  {
+    rank: 2,
+    name: 'ADI CALL',
+    wkn: 'JV653M',
+    score: 95,
+    scoreMax: 115,
+    strike: 330,
+    price: 2.62,
+    spreadPct: 0.76,
+    omega: 6.1,
+    leverage: 10.7,
+    durationDays: 124,
+    impliedVolPct: 37.6,
+    premiumPct: 9.0,
+    thetaPerDayPct: 2.8,
+    breakEvenMovePct: 8.9,
+    issuer: 'J.P. Morgan',
+    stakeholderInfo: 'Fokus auf ADI mit solidem Omega bei längerer Laufzeit.',
+    setup200: { pieces: 76, entry: 2.62, stop: 2.358, cost: 199.12, risk: 19.91 },
+  },
+];
+
+const tableBody = document.getElementById('tradesTableBody');
+const schemaPreview = document.getElementById('schemaPreview');
+const rowTemplate = document.getElementById('rowTemplate');
+
+document.getElementById('jsonFile').addEventListener('change', handleFileUpload);
+document.getElementById('loadSampleBtn').addEventListener('click', () => {
+  persistTrades(sampleData);
+  render(sampleData);
+});
+document.getElementById('clearBtn').addEventListener('click', () => {
+  localStorage.removeItem(STORAGE_KEY);
+  render([]);
+});
+
+schemaPreview.textContent = JSON.stringify(schemaExample, null, 2);
+
+const persisted = readPersistedTrades();
+render(persisted.length ? persisted : []);
+
+function handleFileUpload(event) {
+  const file = event.target.files?.[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const raw = JSON.parse(String(reader.result));
+      const rows = normalizeInput(raw);
+      if (!rows.length) throw new Error('Keine gültigen Trade-Objekte gefunden.');
+      persistTrades(rows);
+      render(rows);
+    } catch (error) {
+      alert(`JSON konnte nicht verarbeitet werden: ${error.message}`);
+    }
+  };
+  reader.readAsText(file);
+}
+
+function normalizeInput(raw) {
+  const arr = Array.isArray(raw) ? raw : [raw];
+  return arr
+    .map((item) => ({
+      rank: Number(item.rank ?? item.Rang ?? 0),
+      name: String(item.name ?? item.Name ?? '-'),
+      wkn: String(item.wkn ?? item.WKN ?? '-'),
+      score: Number(item.score ?? item.gesamtScore ?? 0),
+      scoreMax: Number(item.scoreMax ?? item.score_max ?? 115),
+      spreadPct: Number(item.spreadPct ?? item.spread ?? 0),
+      omega: Number(item.omega ?? 0),
+      breakEvenMovePct: Number(item.breakEvenMovePct ?? item.breakEvenPct ?? 0),
+      thetaPerDayPct: Number(item.thetaPerDayPct ?? item.thetaPct ?? 0),
+      issuer: String(item.issuer ?? item.emittent ?? '-'),
+      stakeholderInfo: String(item.stakeholderInfo ?? item.info ?? '-'),
+      setup200: {
+        risk: Number(item?.setup200?.risk ?? item.risk200 ?? 0),
+      },
+    }))
+    .filter((x) => x.name !== '-');
+}
+
+function render(rows) {
+  tableBody.innerHTML = '';
+
+  for (const row of rows) {
+    const clone = rowTemplate.content.cloneNode(true);
+    const values = {
+      rank: row.rank || '-',
+      name: row.name,
+      wkn: row.wkn,
+      score: `${row.score}/${row.scoreMax}`,
+      spread: `${row.spreadPct.toFixed(2)}%`,
+      omega: row.omega.toFixed(1),
+      breakEvenMove: `${row.breakEvenMovePct.toFixed(1)}%`,
+      thetaPerDay: `${row.thetaPerDayPct.toFixed(1)}%`,
+      issuer: row.issuer,
+      stakeholderInfo: row.stakeholderInfo,
+    };
+
+    Object.entries(values).forEach(([key, value]) => {
+      clone.querySelector(`[data-key="${key}"]`).textContent = value;
+    });
+
+    tableBody.appendChild(clone);
+  }
+
+  renderStats(rows);
+}
+
+function renderStats(rows) {
+  const count = rows.length;
+  const avgScore = average(rows.map((r) => r.score));
+  const avgSpread = average(rows.map((r) => r.spreadPct));
+  const avgTheta = average(rows.map((r) => r.thetaPerDayPct));
+  const avgRisk = average(rows.map((r) => r.setup200?.risk ?? 0));
+
+  const issuerCounts = rows.reduce((acc, row) => {
+    acc[row.issuer] = (acc[row.issuer] || 0) + 1;
+    return acc;
+  }, {});
+
+  const bestIssuer = Object.entries(issuerCounts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '-';
+
+  text('statTrades', count);
+  text('statAvgScore', count ? avgScore.toFixed(1) : '0');
+  text('statAvgSpread', `${avgSpread.toFixed(2)}%`);
+  text('statAvgTheta', `${avgTheta.toFixed(2)}%`);
+  text('statBestIssuer', bestIssuer);
+  text('statAvgRisk', `${avgRisk.toFixed(2)}€`);
+}
+
+function text(id, value) {
+  document.getElementById(id).textContent = String(value);
+}
+
+function average(values) {
+  if (!values.length) return 0;
+  return values.reduce((a, b) => a + Number(b || 0), 0) / values.length;
+}
+
+function readPersistedTrades() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? normalizeInput(JSON.parse(raw)) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistTrades(rows) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(rows));
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trading Logbuch – Optionsscheine</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="header">
+      <h1>Trading Logbuch</h1>
+      <p>JSON hochladen, Trades nachverfolgen und aus Fehlern lernen.</p>
+    </header>
+
+    <main class="layout">
+      <section class="card controls">
+        <h2>Import</h2>
+        <p>Unterstützt Einzelobjekt oder Array aus Trades.</p>
+        <input id="jsonFile" type="file" accept="application/json" />
+        <div class="button-row">
+          <button id="loadSampleBtn" type="button">Beispiel laden</button>
+          <button id="clearBtn" type="button" class="danger">Logbuch löschen</button>
+        </div>
+        <details>
+          <summary>Erwartetes JSON-Schema</summary>
+          <pre id="schemaPreview"></pre>
+        </details>
+      </section>
+
+      <section class="card metrics">
+        <h2>Dashboard</h2>
+        <div class="stats-grid">
+          <article><h3>Trades</h3><strong id="statTrades">0</strong></article>
+          <article><h3>Ø Score</h3><strong id="statAvgScore">0</strong></article>
+          <article><h3>Ø Spread</h3><strong id="statAvgSpread">0%</strong></article>
+          <article><h3>Ø Theta/Tag</h3><strong id="statAvgTheta">0%</strong></article>
+          <article><h3>Top Emittent</h3><strong id="statBestIssuer">-</strong></article>
+          <article><h3>Ø Risiko (200€)</h3><strong id="statAvgRisk">0€</strong></article>
+        </div>
+      </section>
+
+      <section class="card full-width">
+        <h2>Trade-Übersicht</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Rang</th>
+                <th>Name</th>
+                <th>WKN</th>
+                <th>Score</th>
+                <th>Spread</th>
+                <th>Omega</th>
+                <th>Break-Even Move</th>
+                <th>Theta/Tag</th>
+                <th>Emittent</th>
+                <th>Stakeholder-Info</th>
+              </tr>
+            </thead>
+            <tbody id="tradesTableBody"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <template id="rowTemplate">
+      <tr>
+        <td data-key="rank"></td>
+        <td data-key="name"></td>
+        <td data-key="wkn"></td>
+        <td data-key="score"></td>
+        <td data-key="spread"></td>
+        <td data-key="omega"></td>
+        <td data-key="breakEvenMove"></td>
+        <td data-key="thetaPerDay"></td>
+        <td data-key="issuer"></td>
+        <td data-key="stakeholderInfo"></td>
+      </tr>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1,0 +1,156 @@
+:root {
+  color-scheme: dark;
+  --bg: #090c12;
+  --card: #121926;
+  --text: #e8edf7;
+  --muted: #91a1bf;
+  --accent: #6ea8fe;
+  --success: #34d399;
+  --danger: #ef4444;
+  --border: #253146;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, sans-serif;
+  background: radial-gradient(circle at top right, #18243d, var(--bg) 40%);
+  color: var(--text);
+}
+
+.header {
+  padding: 2rem 2rem 1rem;
+}
+
+.header h1 {
+  margin: 0 0 0.4rem;
+}
+
+.header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(280px, 1fr));
+  gap: 1rem;
+  padding: 1rem 2rem 2rem;
+}
+
+.card {
+  background: color-mix(in srgb, var(--card) 95%, black);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+h2 {
+  margin-top: 0;
+}
+
+input[type='file'],
+button {
+  width: 100%;
+  margin-top: 0.6rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0f1523;
+  color: var(--text);
+  padding: 0.65rem;
+}
+
+button {
+  cursor: pointer;
+  border-color: #3d5ea6;
+  background: #16274d;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+.button-row {
+  display: flex;
+  gap: 0.6rem;
+}
+
+button.danger {
+  background: #3a1118;
+  border-color: #7f1d1d;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.stats-grid article {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.7rem;
+  background: #0d1420;
+}
+
+.stats-grid h3 {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.stats-grid strong {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 1.2rem;
+  color: var(--success);
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.65rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+pre {
+  white-space: pre-wrap;
+  background: #0a111d;
+  padding: 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+@media (max-width: 980px) {
+  .layout {
+    grid-template-columns: 1fr;
+    padding: 1rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple, local web UI to capture and review options-trade analysis output for post-trade learning and debugging. 
- Enable quick import of analysis results (single object or array) so trades from the scanner can be archived and inspected.

### Description

- Added a static dashboard web app under `dashboard/` with `index.html`, `styles.css` and `app.js` that renders KPI cards and a trade table. 
- Implemented JSON import (file upload), input normalization (accepts English and German keys), sample-data quick-load, and persistence via `localStorage`. 
- Included a small example dataset matching the provided optionschein outputs and a README section (`README.md`) documenting how to launch the dashboard locally. 
- The UI computes summary KPIs (Ø Score, Ø Spread, Ø Theta/Tag, Ø Risiko, Top Emittent) and shows stakeholder info and setup risk for each trade.

### Testing

- `python -m py_compile warrants_searcher_v6_fixed_3.py` — succeeded. 
- `node --check dashboard/app.js` — succeeded. 
- Local server + automated UI check: served the repo with `python -m http.server` and ran an automated Playwright script to load `dashboard/index.html`, click the sample-data button and capture a screenshot — the UI check completed successfully and a screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9e562e908328b23a185a0551202b)