### PR TITLE
Fix theta scoring to match documented percent-per-day bands

### DIFF
--- a/tests/test_theta_scoring.py
+++ b/tests/test_theta_scoring.py
@@ -1,0 +1,8 @@
+from warrant_scanner.scoring.option_scoring import _score_theta
+
+
+def test_theta_scoring_matches_documented_percent_bands():
+    assert _score_theta(4.9) == 15
+    assert _score_theta(6.5) == 12
+    assert _score_theta(9.9) == 8
+    assert _score_theta(12.0) == 3

--- a/warrant_scanner/scoring/option_scoring.py
+++ b/warrant_scanner/scoring/option_scoring.py
@@ -70,11 +70,12 @@ def _score_strike(distance_pct: float) -> int:
 
 
 def _score_theta(theta_pct: float) -> int:
-    if theta_pct <= 0.5:
+    # theta_pct is already in percent-per-day (e.g. 4.2 == 4.2%)
+    if theta_pct <= 5.0:
         return 15
-    if theta_pct <= 1.0:
+    if theta_pct <= 7.0:
         return 12
-    if theta_pct <= 2.0:
+    if theta_pct <= 10.0:
         return 8
     return 3
 


### PR DESCRIPTION
### Motivation
- Align the `Theta-Score` implementation with the documented percent-per-day bands (<=5%, <=7%, <=10%, else lower) so scoring reflects the README spec.

### Description
- Update `_score_theta` in `warrant_scanner/scoring/option_scoring.py` to use percent-per-day thresholds (`5.0`, `7.0`, `10.0`) and add a unit test `tests/test_theta_scoring.py` that asserts the expected band behavior.

### Testing
- Ran `python -m pytest -q` and the test suite passed (all tests succeeded, including the new `test_theta_scoring`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994cc283e5c8328803b3490e1d464a8)