### PR TITLE
Add Bollinger Bands scoring

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,11 @@ scoring:
   volume:
     above_average: 2
     increasing_3d: 2
+  bollinger:
+    window: 20
+    num_std: 2
+    lower_band_touch: 2
+    lower_band_near: 1
   sideways:
     penalty: -5
   os_ok_min_score: 13  # Min score for basiswert to be OS_OK


### PR DESCRIPTION
## Summary
- Added Bollinger Bands calculation (20-period, 2 standard deviations)
- Added scoring logic:
  - +2 points if price is at or below lower Bollinger Band
  - +1 point if price is within 1% of lower Bollinger Band
- Configurable via config.yaml

## Test plan
- [ ] Run script and verify Bollinger Bands scoring works
- [ ] Check for messages like "✔ Preis am Bollinger Lower Band (Erholungs-Signal)" or "✔ Preis nahe Bollinger Lower Band"

🤖 Generated with [Claude Code](https://claude.com/claude-code)